### PR TITLE
feature(README): Clarify two-step process

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ Debian 9 is not affected by this particular issue.
 
 Running this script on end-of-life distributions such as Ubuntu 12.04 will fail. You are strongly urged to upgrade any out of life distributions.
 
-To apply the fix, simply run:
+To apply the fix, simply download with:
 
 ```
 wget -O fix.sh https://raw.githubusercontent.com/digitalocean/debian-sys-maint-roll-passwd/master/fix.sh
+```
+
+Once you have downloaded the script, you can run it with:
+
+```
 bash fix.sh
 ```
 


### PR DESCRIPTION
Two steps are needed: 1) download 2) run. So I update the README to reflect this.